### PR TITLE
Add Feed and Play buttons with state modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ exports/
 # OS junk
 .DS_Store
 Thumbs.db
+
+# Temporary files
+*.tmp

--- a/client/scenes/hud/hud.gd
+++ b/client/scenes/hud/hud.gd
@@ -1,11 +1,30 @@
 extends CanvasLayer
 
-var hunger: float = 70.0
-var happiness: float = 55.0
+var hunger: float = 0.0
+var happiness: float = 0.0
 
 @onready var hunger_bar = $StatsBars/HungerBar
 @onready var happiness_bar = $StatsBars/HappinessBar
 
+@onready var hunger_button = $StatsButtons/HungerButton
+@onready var happiness_button = $StatsButtons/HappinessButton
+
 func _ready():
-	hunger_bar.value = hunger
-	happiness_bar.value = happiness
+	hunger_button.pressed.connect(_on_hunger_button_pressed)
+	happiness_button.pressed.connect(_on_happiness_button_pressed)
+	update_bars()
+
+
+func _on_hunger_button_pressed() -> void:
+	hunger = clamp(hunger + 10.0, 0.0, 100.0)
+	update_bars()
+
+
+func _on_happiness_button_pressed() -> void:
+	happiness = clamp(happiness + 10.0, 0.0, 100.0)
+	update_bars()
+
+
+func update_bars():
+	hunger_bar.value = clamp(hunger, 0.0, 100.0)
+	happiness_bar.value = clamp(happiness, 0.0, 100.0)

--- a/client/scenes/main.tscn
+++ b/client/scenes/main.tscn
@@ -26,3 +26,26 @@ size_flags_horizontal = 3
 [node name="HappinessBar" type="ProgressBar" parent="HUD/StatsBars" unique_id=1877887279]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="StatsButtons" type="VBoxContainer" parent="HUD" unique_id=321629005]
+custom_minimum_size = Vector2(0, 144)
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -20.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="HungerButton" type="Button" parent="HUD/StatsButtons" unique_id=184703335]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+text = "Feed"
+
+[node name="HappinessButton" type="Button" parent="HUD/StatsButtons" unique_id=2113393694]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+text = "Play"
+
+[connection signal="pressed" from="HUD/StatsButtons/HungerButton" to="HUD" method="_on_hunger_button_pressed"]
+[connection signal="pressed" from="HUD/StatsButtons/HappinessButton" to="HUD" method="_on_happiness_button_pressed"]


### PR DESCRIPTION
Implements the two core player-action buttons that allow the user to interact with the pet by increasing its hunger and happiness stats locally.

## Changes

- Added `HungerButton` and `HappinessButton` nodes inside `StatsButtons` container under the `HUD` CanvasLayer
- Connected button `pressed` signals to handlers via code in `_ready`
- Created `_on_hunger_button_pressed` increasing hunger by 10
- Created `_on_happiness_button_pressed` increasing happiness by 10
- Clamped both stats to `0–100` range using `clamp()`
- Extracted `update_bars()` helper to centralize `ProgressBar` sync
- Wired both buttons to call `update_bars()` after each stat change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Feed" and "Play" buttons to the interface for controlling hunger and happiness stats.
  * Stats now initialize at zero and increment by 10 when buttons are pressed, clamped to valid range.

* **Chores**
  * Updated `.gitignore` to exclude temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->