### PR TITLE
Add pet-server to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Thumbs.db
 
 # Temporary files
 *.tmp
+
+# Server
+server/node_modules/

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "server",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "server",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "server",
+  "version": "0.0.1",
+  "description": "In-memory pet state WebSocket server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "ws": "^8.18.2"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,73 @@
+const { WebSocketServer, WebSocket } = require("ws");
+
+const petState = {
+  hunger: 50,
+  happiness: 50,
+  last_updated: new Date().toISOString(),
+};
+
+const actions = {
+  feed(state) {
+    state.hunger = Math.max(0, state.hunger - 20);
+    state.happiness = Math.min(100, state.happiness + 5);
+  },
+  play(state) {
+    state.happiness = Math.min(100, state.happiness + 20);
+    state.hunger = Math.min(100, state.hunger + 5);
+  },
+};
+
+function broadcast(wss, payload) {
+  const msg = JSON.stringify(payload);
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) client.send(msg);
+  }
+}
+
+const PORT = process.env.PORT || 8080;
+const wss = new WebSocketServer({ port: PORT });
+
+console.log(`Pet WebSocket server listening on port ${PORT}`);
+
+wss.on("connection", (ws) => {
+  console.log("Client connected — sending current state");
+
+  ws.send(JSON.stringify({ type: "state", state: petState }));
+
+  ws.on("message", (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+      return;
+    }
+
+    if (msg.type !== "action") {
+      ws.send(
+        JSON.stringify({ type: "error", message: `Unknown type: ${msg.type}` }),
+      );
+      return;
+    }
+
+    const handler = actions[msg.action];
+    if (!handler) {
+      ws.send(
+        JSON.stringify({
+          type: "error",
+          message: `Unknown action: ${msg.action}`,
+        }),
+      );
+      return;
+    }
+
+    handler(petState);
+    petState.last_updated = new Date().toISOString();
+    console.log(`Action "${msg.action}" → state:`, petState);
+
+    broadcast(wss, { type: "state", state: petState });
+  });
+
+  ws.on("close", () => console.log("Client disconnected"));
+  ws.on("error", (err) => console.error("WebSocket error:", err.message));
+});


### PR DESCRIPTION
Adds a Node.js WebSocket server (`server/`) that holds pet state in memory and broadcasts it to all connected clients. This is the backend for the Bastet virtual pet game, intended to be deployed to Render where it will be reachable over WSS.

## Changes

- Created `server/server.js` with a `WebSocketServer` listening on `process.env.PORT || 8080`
- Added in-memory `petState` object tracking `hunger`, `happiness`, and `last_updated`
- Implemented `feed` and `play` action handlers that mutate state with clamped values
- Added `broadcast()` helper that sends updated state to all connected clients on every action
- Sends current state immediately to each client on connect
- Created `server/package.json` with `ws` dependency and `npm start` script
- Updated `.gitignore` to exclude `server/node_modules/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone real-time WebSocket pet state server that shares a live pet status with connected clients and broadcasts updates.
  * Supports user-triggered pet interactions (feed and play) that update hunger, happiness, and last-updated timestamp.

* **Chores**
  * Updated configuration to exclude server dependency artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->