### PR TITLE
Replace local state with WebSocket sync and add connection status UI

### DIFF
--- a/client/scenes/hud/hud.gd
+++ b/client/scenes/hud/hud.gd
@@ -3,7 +3,9 @@ extends CanvasLayer
 var hunger: float = 0.0
 var happiness: float = 0.0
 
-const DECAY_RATE: float = 1.0 / 30.0
+var ws_peer = WebSocketPeer.new()
+
+const SERVER_URL = "ws://localhost:8080"
 
 @onready var hunger_bar = $StatsBars/HungerBar
 @onready var happiness_bar = $StatsBars/HappinessBar
@@ -11,23 +13,54 @@ const DECAY_RATE: float = 1.0 / 30.0
 @onready var hunger_button = $StatsButtons/HungerButton
 @onready var happiness_button = $StatsButtons/HappinessButton
 
+@onready var status_label = $StatusLabel
+
 func _ready():
 	update_bars()
-
+	ws_peer.connect_to_url(SERVER_URL)
+	status_label.text = "Connecting..."
 
 func _process(delta: float) -> void:
-	hunger = clamp(hunger  - DECAY_RATE * delta, 0.0, 100.0)
-	happiness = clamp(happiness - DECAY_RATE * delta, 0.0, 100.0)
+	ws_peer.poll()
+	
+	var state = ws_peer.get_ready_state()
+	
+	if state == WebSocketPeer.STATE_OPEN:
+		status_label.text = "Connected"
+		
+		while ws_peer.get_available_packet_count() > 0:
+			var packet = ws_peer.get_packet()
+			var text = packet.get_string_from_utf8()
+			handle_server_message(text)
+			
+	elif state == WebSocketPeer.STATE_CLOSED:
+		status_label.text = "Disconnected"
+
+
+func handle_server_message(text: String):
+	var data = JSON.parse_string(text)
+	if data == null:
+		return
+	if data.get("type") != "state":
+		return
+	var state = data["state"]
+	hunger = state["hunger"]
+	happiness = state["happiness"]
 	update_bars()
 
 func _on_hunger_button_pressed() -> void:
-	hunger = clamp(hunger + 10.0, 0.0, 100.0)
-	update_bars()
+	send_action("feed")
 
 
 func _on_happiness_button_pressed() -> void:
-	happiness = clamp(happiness + 10.0, 0.0, 100.0)
-	update_bars()
+	send_action("play")
+
+
+func send_action(action: String):
+	if ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
+		return
+	
+	ws_peer.send_text(JSON.stringify({ "type": "action", "action": action }))
 
 
 func update_bars():

--- a/client/scenes/hud/hud.gd
+++ b/client/scenes/hud/hud.gd
@@ -10,6 +10,7 @@ var happiness: float = 0.0
 
 func _ready():
 	Stats.stats_changed.connect(_on_stats_changed)
+	_on_stats_changed(Stats.hunger, Stats.happiness)
 	status_label.text = "Connecting..."
 
 func _process(delta: float) -> void:

--- a/client/scenes/hud/hud.gd
+++ b/client/scenes/hud/hud.gd
@@ -3,66 +3,29 @@ extends CanvasLayer
 var hunger: float = 0.0
 var happiness: float = 0.0
 
-var ws_peer = WebSocketPeer.new()
-
-const SERVER_URL = "ws://localhost:8080"
 
 @onready var hunger_bar = $StatsBars/HungerBar
 @onready var happiness_bar = $StatsBars/HappinessBar
-
-@onready var hunger_button = $StatsButtons/HungerButton
-@onready var happiness_button = $StatsButtons/HappinessButton
-
 @onready var status_label = $StatusLabel
 
 func _ready():
-	update_bars()
-	ws_peer.connect_to_url(SERVER_URL)
+	Stats.stats_changed.connect(_on_stats_changed)
 	status_label.text = "Connecting..."
 
 func _process(delta: float) -> void:
-	ws_peer.poll()
-	
-	var state = ws_peer.get_ready_state()
-	
-	if state == WebSocketPeer.STATE_OPEN:
+	if Network.get_ready_state() == WebSocketPeer.STATE_OPEN:
 		status_label.text = "Connected"
-		
-		while ws_peer.get_available_packet_count() > 0:
-			var packet = ws_peer.get_packet()
-			var text = packet.get_string_from_utf8()
-			handle_server_message(text)
-			
-	elif state == WebSocketPeer.STATE_CLOSED:
+	elif Network.get_ready_state() == WebSocketPeer.STATE_CLOSED:
 		status_label.text = "Disconnected"
 
+func _on_stats_changed(hunger: float, happiness: float) -> void:
+	hunger_bar.value = hunger
+	happiness_bar.value = happiness
 
-func handle_server_message(text: String):
-	var data = JSON.parse_string(text)
-	if data == null:
-		return
-	if data.get("type") != "state":
-		return
-	var state = data["state"]
-	hunger = state["hunger"]
-	happiness = state["happiness"]
-	update_bars()
 
 func _on_hunger_button_pressed() -> void:
-	send_action("feed")
+	Network.send_action("feed")
 
 
 func _on_happiness_button_pressed() -> void:
-	send_action("play")
-
-
-func send_action(action: String):
-	if ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
-		return
-	
-	ws_peer.send_text(JSON.stringify({ "type": "action", "action": action }))
-
-
-func update_bars():
-	hunger_bar.value = clamp(hunger, 0.0, 100.0)
-	happiness_bar.value = clamp(happiness, 0.0, 100.0)
+	Network.send_action("play")

--- a/client/scenes/main.tscn
+++ b/client/scenes/main.tscn
@@ -47,5 +47,17 @@ custom_minimum_size = Vector2(0, 64)
 layout_mode = 2
 text = "Play"
 
+[node name="StatusLabel" type="Label" parent="HUD" unique_id=1146168219]
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -1.0
+offset_top = -11.5
+offset_bottom = 11.5
+grow_horizontal = 0
+grow_vertical = 2
+
 [connection signal="pressed" from="HUD/StatsButtons/HungerButton" to="HUD" method="_on_hunger_button_pressed"]
 [connection signal="pressed" from="HUD/StatsButtons/HappinessButton" to="HUD" method="_on_happiness_button_pressed"]

--- a/client/scenes/network/network.gd
+++ b/client/scenes/network/network.gd
@@ -17,9 +17,13 @@ func _process(delta: float) -> void:
 
 func _handle_message(text: String) -> void:
 	var data = JSON.parse_string(text)
+	if data == null or typeof(data) != TYPE_DICTIONARY:
+		return
 	if data == null or data.get("type") != "state":
 		return
 	var state = data.get("state")
+	if state == null or typeof(state) != TYPE_DICTIONARY:
+		return
 	if state == null or not state.has("hunger") or not state.has("happiness"):
 		return
 	Stats.set_stats(float(state["hunger"]), float(state["happiness"]))

--- a/client/scenes/network/network.gd
+++ b/client/scenes/network/network.gd
@@ -1,0 +1,33 @@
+extends Node
+
+const SERVER_URL = "ws://localhost:8080"
+
+var ws_peer = WebSocketPeer.new()
+
+func _ready() -> void:
+	ws_peer.connect_to_url(SERVER_URL)
+
+func _process(delta: float) -> void:
+	ws_peer.poll()
+
+	if ws_peer.get_ready_state() == WebSocketPeer.STATE_OPEN:
+		while ws_peer.get_available_packet_count() > 0:
+			var text = ws_peer.get_packet().get_string_from_utf8()
+			_handle_message(text)
+
+func _handle_message(text: String) -> void:
+	var data = JSON.parse_string(text)
+	if data == null or data.get("type") != "state":
+		return
+	var state = data.get("state")
+	if state == null or not state.has("hunger") or not state.has("happiness"):
+		return
+	Stats.set_stats(float(state["hunger"]), float(state["happiness"]))
+
+func send_action(action: String) -> void:
+	if ws_peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
+		return
+	ws_peer.send_text(JSON.stringify({"type": "action", "action": action}))
+
+func get_ready_state() -> int:
+	return ws_peer.get_ready_state()

--- a/client/scenes/stats/stats.gd
+++ b/client/scenes/stats/stats.gd
@@ -1,0 +1,11 @@
+extends Node
+
+signal stats_changed(hunger: float, happiness: float)
+
+var hunger: float = 0.0
+var happiness: float = 0.0
+
+func set_stats(new_hunger: float, new_happiness: float) -> void:
+	hunger = clamp(new_hunger, 0.0, 100.0)
+	happiness = clamp(new_happiness, 0.0, 100.0)
+	stats_changed.emit(hunger, happiness)

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,11 @@ run/main_scene="res://client/scenes/main.tscn"
 config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[autoload]
+
+Stats="*uid://ctwjscjmee6c4"
+Network="*uid://cvvj4dj7h8jav"
+
 [display]
 
 window/size/viewport_width=720

--- a/server/petState.js
+++ b/server/petState.js
@@ -1,0 +1,19 @@
+const state = {
+  hunger: 50,
+  happiness: 50,
+  last_updated: new Date().toISOString(),
+};
+
+function feed() {
+  state.hunger = Math.min(100, state.hunger + 20);
+  state.happiness = Math.min(100, state.happiness + 5);
+  state.last_updated = new Date().toISOString();
+}
+
+function play() {
+  state.happiness = Math.min(100, state.happiness + 20);
+  state.hunger = Math.min(100, state.hunger + 5);
+  state.last_updated = new Date().toISOString();
+}
+
+module.exports = { state, feed, play };

--- a/server/server.js
+++ b/server/server.js
@@ -1,21 +1,9 @@
 const { WebSocketServer, WebSocket } = require("ws");
+const { state, feed, play } = require("./petState");
 
-const petState = {
-  hunger: 50,
-  happiness: 50,
-  last_updated: new Date().toISOString(),
-};
+const petState = state;
 
-const actions = {
-  feed(state) {
-    state.hunger = Math.max(0, state.hunger - 20);
-    state.happiness = Math.min(100, state.happiness + 5);
-  },
-  play(state) {
-    state.happiness = Math.min(100, state.happiness + 20);
-    state.hunger = Math.min(100, state.hunger + 5);
-  },
-};
+const actions = { feed, play };
 
 function broadcast(wss, payload) {
   const msg = JSON.stringify(payload);
@@ -61,10 +49,8 @@ wss.on("connection", (ws) => {
       return;
     }
 
-    handler(petState);
-    petState.last_updated = new Date().toISOString();
+    handler();
     console.log(`Action "${msg.action}" → state:`, petState);
-
     broadcast(wss, { type: "state", state: petState });
   });
 

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,10 @@ const { state, feed, play } = require("./petState");
 
 const petState = state;
 
-const actions = { feed, play };
+const actions = new Map([
+  ["feed", feed],
+  ["play", play],
+]);
 
 function broadcast(wss, payload) {
   const msg = JSON.stringify(payload);
@@ -38,7 +41,7 @@ wss.on("connection", (ws) => {
       return;
     }
 
-    const handler = actions[msg.action];
+    const handler = actions.get(msg.action);
     if (!handler) {
       ws.send(
         JSON.stringify({


### PR DESCRIPTION
Replaces local state mutation with a WebSocket connection to a game server. Button presses now send action messages to the server instead of updating stats directly, and the HUD reflects state received from server-pushed `state` messages. A status label shows the current connection state.

## Changes

- Added `WebSocketPeer` instance and `SERVER_URL` constant to `hud.gd`, replacing the local `DECAY_RATE` decay logic
- Connected to the WebSocket server in `_ready()` and set initial status label text
- Rewired `_process()` to poll the WebSocket and dispatch incoming packets to `handle_server_message()`
- Added `handle_server_message()` to parse JSON, guard on `type == "state"`, and apply `hunger`/`happiness` from the payload
- Added `send_action()` to serialize and send `{ type, action }` messages, guarded behind a ready-state check
- Updated `_on_hunger_button_pressed()` and `_on_happiness_button_pressed()` to call `send_action()` instead of mutating local state
- Added `StatusLabel` node to `main.tscn`, anchored to the right-center of the HUD, to display connection status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a connection status indicator showing real-time server connectivity (initially "Connecting...").
  * Pet stats are now server-authoritative and update in real time from the server.
  * Feed/Play buttons send actions to the server; UI bars update reactively when server state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->