### PR TITLE
Refactor WebSocket server to use HTTP upgrade model

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,5 @@
 const { WebSocketServer, WebSocket } = require("ws");
+const http = require("http");
 const { state, feed, play } = require("./petState");
 
 const petState = state;
@@ -15,10 +16,12 @@ function broadcast(wss, payload) {
   }
 }
 
+const server = http.createServer();
+const wss = new WebSocketServer({ server });
 const PORT = process.env.PORT || 8080;
-const wss = new WebSocketServer({ port: PORT });
+server.listen(PORT);
 
-console.log(`Pet WebSocket server listening on port ${PORT}`);
+console.log(`Server listening on ${PORT}`);
 
 wss.on("connection", (ws) => {
   console.log("Client connected — sending current state");


### PR DESCRIPTION
This refactors the WebSocket server transport layer to use an HTTP server as the base for upgrade handling, making it compatible with proxy-based deployment environments like :contentReference[oaicite:0]{index=0}. The WebSocket server is no longer bound directly to a port and instead attaches to a shared HTTP server instance. Server startup logging is updated to reflect the HTTP server lifecycle rather than a WebSocket-specific listener.

## Changes

- Introduced `http` module and created a shared HTTP server via `http.createServer()`
- Replaced `new WebSocketServer({ port: PORT })` with `new WebSocketServer({ server })` to enable HTTP upgrade handling
- Removed direct WebSocket port binding in favor of `server.listen(PORT)`
- Updated startup logging from WebSocket-specific message to HTTP server binding message
- Ensured `PORT` is consistently sourced from `process.env.PORT` with fallback to `8080`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated server configuration to improve architecture and compatibility. The server continues to listen on the same port and serve WebSocket connections with no changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->